### PR TITLE
sublime-text: disable sublime-text by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Also I copied this intro verbatim from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Changed:
+* Sublime Text is now disabled by default, since ST4 is able to sync with system dark-mode
 
 ## [v0.13.1 - 2021-11-05]
 ### Fixed:

--- a/thcon/src/themeable.rs
+++ b/thcon/src/themeable.rs
@@ -11,7 +11,7 @@ pub trait Themeable {
     fn switch(&self, config: &ThconConfig, operation: &Operation) -> Result<()>;
 }
 
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Debug)]
 pub enum ConfigState {
     NoDefault,
     Default,


### PR DESCRIPTION
Previous commits mentioned that Sublime Text is disabled by default, but none of them actually disabled the switching logic for that app.  Notably:

* dfa2c3d (sublime_text: disable sublime-text by default, 2021-08-04)
* 56bb446 (docs-site: add pages for Sublime Text 3 and 4, 2021-08-04)

Actually disable the sublime-text app by default, aligning the implementation with the documentation.
