### PR TITLE
style: replace needless constructor functions

### DIFF
--- a/lib/apps/apps_darwin.go
+++ b/lib/apps/apps_darwin.go
@@ -1,11 +1,11 @@
 package apps
 
 var All = []Switchable{
-	NewMacOS(),
-	&TerminalDotApp{},
-	&Iterm2{},
+	new(MacOS),
+	new(TerminalDotApp),
+	new(Iterm2),
 	NewVim(),
 	NewNeovim(),
-	NewHelix(),
-	NewKitty(),
+	new(Helix),
+	new(Kitty),
 }

--- a/lib/apps/apps_freebsd.go
+++ b/lib/apps/apps_freebsd.go
@@ -2,17 +2,17 @@ package apps
 
 var All = []Switchable{
 	// GNOME
-	NewGtk3(),
-	NewGnomeShell(),
-	NewGnomeTerminal(),
+	new(Gtk3),
+	new(GnomeShell),
+	new(GnomeTerminal),
 
 	// KDE
-	NewKonsole(),
-	NewPlasma(),
+	new(Konsole),
+	new(Plasma),
 
 	// Cross-platform
 	NewVim(),
 	NewNeovim(),
-	NewHelix(),
-	NewKitty(),
+	new(Helix),
+	new(Kitty),
 }

--- a/lib/apps/apps_linux.go
+++ b/lib/apps/apps_linux.go
@@ -2,17 +2,17 @@ package apps
 
 var All = []Switchable{
 	// GNOME
-	NewGtk3(),
-	NewGnomeShell(),
-	NewGnomeTerminal(),
+	new(Gtk3),
+	new(GnomeShell),
+	new(GnomeTerminal),
 
 	// KDE
-	NewKonsole(),
-	NewPlasma(),
+	new(Konsole),
+	new(Plasma),
 
 	// Cross-platform
 	NewVim(),
 	NewNeovim(),
-	NewHelix(),
-	NewKitty(),
+	new(Helix),
+	new(Kitty),
 }

--- a/lib/apps/gnome_shell.go
+++ b/lib/apps/gnome_shell.go
@@ -22,10 +22,6 @@ type GnomeShell struct{}
 
 var _ Switchable = (*GnomeShell)(nil)
 
-func NewGnomeShell() Switchable {
-	return &GnomeShell{}
-}
-
 func (g *GnomeShell) ValidateConfig(ctx context.Context, config *Config) (health.Status, error) {
 	return health.RequiresConfig(ctx, config.GnomeShell)
 }

--- a/lib/apps/gnome_terminal.go
+++ b/lib/apps/gnome_terminal.go
@@ -26,10 +26,6 @@ type GnomeTerminalConfig struct {
 
 type GnomeTerminal struct{}
 
-func NewGnomeTerminal() Switchable {
-	return &GnomeTerminal{}
-}
-
 type windowNode struct {
 	XMLName xml.Name `xml:"node"`
 	Name    string   `xml:"name,attr"`

--- a/lib/apps/gtk3.go
+++ b/lib/apps/gtk3.go
@@ -20,10 +20,6 @@ type Gtk3Config struct {
 
 type Gtk3 struct{}
 
-func NewGtk3() Switchable {
-	return &Gtk3{}
-}
-
 func (g *Gtk3) ValidateConfig(ctx context.Context, config *Config) (health.Status, error) {
 	return health.HasDefaults(ctx, config.Gtk3)
 }

--- a/lib/apps/helix.go
+++ b/lib/apps/helix.go
@@ -29,10 +29,6 @@ type helixConfig struct {
 
 type Helix struct{}
 
-func NewHelix() *Helix {
-	return &Helix{}
-}
-
 var _ Switchable = (*Helix)(nil)
 
 func (h *Helix) ValidateConfig(ctx context.Context, config *Config) (health.Status, error) {

--- a/lib/apps/kitty.go
+++ b/lib/apps/kitty.go
@@ -28,10 +28,6 @@ type kittyConfig struct {
 
 type Kitty struct{}
 
-func NewKitty() *Kitty {
-	return &Kitty{}
-}
-
 var _ Switchable = (*Kitty)(nil)
 
 func (k *Kitty) ValidateConfig(ctx context.Context, config *Config) (health.Status, error) {

--- a/lib/apps/konsole.go
+++ b/lib/apps/konsole.go
@@ -25,10 +25,6 @@ type KonsoleConfig struct {
 
 type Konsole struct{}
 
-func NewKonsole() Switchable {
-	return &Konsole{}
-}
-
 func (k *Konsole) Name() string {
 	const name = "Konsole"
 	return name

--- a/lib/apps/macos.go
+++ b/lib/apps/macos.go
@@ -23,10 +23,6 @@ type MacOS struct{}
 
 var _ Switchable = (*MacOS)(nil)
 
-func NewMacOS() Switchable {
-	return &MacOS{}
-}
-
 func (m *MacOS) ValidateConfig(ctx context.Context, config *Config) (health.Status, error) {
 	return health.HasDefaults(ctx, config.MacOS)
 }

--- a/lib/apps/plasma.go
+++ b/lib/apps/plasma.go
@@ -22,10 +22,6 @@ type PlasmaConfig struct {
 
 type Plasma struct{}
 
-func NewPlasma() Switchable {
-	return &Plasma{}
-}
-
 func (p *Plasma) Name() string {
 	const name = "Plasma"
 	return name


### PR DESCRIPTION
Functions that return a pointer to a zero-valued struct are equivalent to new(). Just use new().