### PR TITLE
kitty: remove default config path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Also I copied this intro verbatim from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
-### Added
+### Added:
 * [Alacritty](https://alacritty.org) support
 
+### Removed:
+* Default dark-mode/light-mode config paths for kitty
+
 ## [v0.15.5 - 2023-08-31]
-### Fixed
+### Fixed:
 * No longer reports errors when calling lookandfeeltool on systems without KDE installed.
 * No longer reports errors when switching helix themes where a ~/.config/helix directory doesn't exist.
 
-### Changed
+### Changed:
 * Skipped apps now use a separate "reason" field when info-level logging (-v) is enabled, instead of listing the skip-reason in the message itself.
 
 ## [v0.15.4 - 2023-08-11]
-### Fixed
+### Fixed:
 * Align version number with released version number
 
 ## [v0.15.3 - 2023-08-11]

--- a/docs/content/apps/kitty.md
+++ b/docs/content/apps/kitty.md
@@ -10,8 +10,9 @@ setup: |
   No additional plugins are required to control kitty themes but there is a
   tiny amount of setup:
 
-  1. Split your dark mode and light mode themes into separate `.conf` files (or use
-     [iTerm2-Color-Schemes](https://github.com/mbadolato/iTerm2-Color-Schemes))
+  1. Split your dark mode and light mode themes into separate `.conf` files, or
+     skip this step and use pre-defined themes from
+     [iTerm2-Color-Schemes](https://github.com/mbadolato/iTerm2-Color-Schemes):
      `~/.config/kitty/{dark,light}.thcon.conf`
   2. Use the paths to those files in `thcon.toml` (examples below)
   3. Replace the [color settings](https://sw.kovidgoyal.net/kitty/conf/#color-scheme)
@@ -47,10 +48,10 @@ setup: |
 
 options:
   - key: dark
-    default: ~/.config/kitty/dark.thcon.conf
+    default: (none)
     description: Path to the file defining dark mode settings
   - key: light
-    default: ~/.config/kitty/light.thcon.conf
+    default: (none)
     description: Path to the file defining light mode settings
 example: |
   [kitty]

--- a/lib/apps/kitty.go
+++ b/lib/apps/kitty.go
@@ -31,21 +31,17 @@ type Kitty struct{}
 var _ Switchable = (*Kitty)(nil)
 
 func (k *Kitty) ValidateConfig(ctx context.Context, config *Config) (health.Status, error) {
-	return health.HasDefaults(ctx, config.Kitty)
+	return health.RequiresConfig(ctx, config.Kitty)
 }
 
 func (k *Kitty) Switch(ctx context.Context, mode operation.Operation, config *Config) error {
 	// 1) Replace the ~/.local/state/thcon/kitty-theme.conf symlink
-	var themeConfig *kittyConfig = config.Kitty
-	if themeConfig == nil {
-		themeConfig = &kittyConfig{
-			Dark:  "~/.config/kitty/dark.thcon.conf",
-			Light: "~/.config/kitty/light.thcon.conf",
-		}
+	if config.Kitty == nil {
+		return nil
 	}
-	var themePath = themeConfig.Dark
+	var themePath = config.Kitty.Dark
 	if mode == operation.LightMode {
-		themePath = themeConfig.Light
+		themePath = config.Kitty.Light
 	}
 	themePath, err := homedir.Expand(themePath)
 	if err != nil {


### PR DESCRIPTION
The kitty implementation previously assumed
~/.config/kitty/{dark,light}.thcon.conf if no config files were present in thcon.toml, but those files had to be manually created. Don't let people skip that step by removing the default values for .kitty.dark and .kitty.light.